### PR TITLE
Aop

### DIFF
--- a/src/main/java/org/example/expert/aop/AdminAccessLoggingAspect.java
+++ b/src/main/java/org/example/expert/aop/AdminAccessLoggingAspect.java
@@ -1,0 +1,110 @@
+package org.example.expert.aop;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.example.expert.domain.common.dto.AuthUser;
+import org.example.expert.domain.log.admin.AdminAccessLog;
+import org.example.expert.domain.log.admin.AdminAccessLogRepository;
+import org.example.expert.domain.user.entity.User;
+import org.example.expert.util.CustomUtil;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class AdminAccessLoggingAspect {
+
+    private final AdminAccessLogRepository adminAccessLogRepository;
+
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.PostMapping)")
+    public void postMapping() {
+    }
+
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.GetMapping)")
+    public void getMapping() {
+    }
+
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.PutMapping)")
+    public void putMapping() {
+    }
+
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.DeleteMapping)")
+    public void deleteMapping() {
+    }
+
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.PatchMapping)")
+    public void patchMapping() {
+    }
+
+    @Around("postMapping() || getMapping() || putMapping() || deleteMapping() || patchMapping()")
+    public Object logAdminAccess(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        //url 가져오기
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        String uri = request.getRequestURI();
+
+        //admin 경로가 아니라면 리턴
+        if (!uri.contains("/admin")) {
+            return joinPoint.proceed();
+        }
+
+        //로그 필수 정보 가져오기 (사용자, 접근 시각, 요청 바디, 응답 바디, 요청 uri)
+        Long userId = (Long) request.getAttribute("userId");
+        User user = User.fromAuthUser(new AuthUser(userId, null, null));
+        LocalDateTime accessTime = LocalDateTime.now();
+        String requestBody = getRequestBody(request);
+
+        //관리자가 요청한 메서드 실행
+        Object result = joinPoint.proceed();
+        String responseBody = getResponseBody(result);
+
+        //로그 저장
+        AdminAccessLog adminAccessLog = AdminAccessLog.builder()
+                .accessTime(accessTime)
+                .user(user)
+                .requestBody(requestBody)
+                .responseBody(responseBody)
+                .requestUrl(uri)
+                .build();
+        adminAccessLogRepository.save(adminAccessLog);
+        log.info("admin API 접속 - 유저 ID: {}, 시각: {}, URL: {}", userId, accessTime, uri);
+
+        return result;
+    }
+
+    private String getRequestBody(HttpServletRequest request) {
+        try {
+            String body = request.getReader().lines()
+                    .collect(Collectors.joining(System.lineSeparator()));
+            return StringUtils.hasText(body) ? body : null;
+        } catch (IOException | IllegalStateException e) {
+            log.warn("요청 바디 본문을 읽는 중 오류 발생: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private String getResponseBody(Object result) {
+        try {
+            return result != null ? CustomUtil.convertToJson(result) : null;
+        } catch (JsonProcessingException e) {
+            log.warn("응답 바디 본문을 읽는 중 오류 발생: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+
+}

--- a/src/main/java/org/example/expert/config/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/expert/config/GlobalExceptionHandler.java
@@ -17,6 +17,11 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResult<ApiError>> handleGeneralException(Exception e) {
+        return new ResponseEntity<>(ApiResult.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResult<Map<String, String>>> validationException(MethodArgumentNotValidException e) {
         Map<String, String> errorMap = new HashMap<>();
@@ -31,7 +36,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(InvalidRequestException.class)
-    public ResponseEntity<ApiResult<ApiError>> invalidRequestExceptionException(InvalidRequestException ex) {
+    public ResponseEntity<ApiResult<ApiError>> handleInvalidRequestException(InvalidRequestException ex) {
         return new ResponseEntity<>(ApiResult.error(ex.getErrorCode().getStatus(), ex.getErrorCode().getMsg()), HttpStatus.BAD_REQUEST);
     }
 
@@ -43,10 +48,9 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(ServerException.class)
-    public ResponseEntity<Map<String, Object>> handleServerException(ServerException ex) {
-        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+    public ResponseEntity<ApiResult<ApiError>> handleServerException(ServerException ex) {
+        return new ResponseEntity<>(ApiResult.error(ex.getErrorCode().getStatus(), ex.getErrorCode().getMsg()), HttpStatus.BAD_REQUEST);
 
-        return getErrorResponse(status, ex.getMessage());
     }
 
     public ResponseEntity<Map<String, Object>> getErrorResponse(HttpStatus status, String message) {

--- a/src/main/java/org/example/expert/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/expert/domain/auth/controller/AuthController.java
@@ -7,6 +7,8 @@ import org.example.expert.domain.auth.dto.request.SignupRequest;
 import org.example.expert.domain.auth.dto.response.SigninResponse;
 import org.example.expert.domain.auth.dto.response.SignupResponse;
 import org.example.expert.domain.auth.service.AuthService;
+import org.example.expert.util.api.ApiResult;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,12 +22,12 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/join")
-    public SignupResponse join(@Valid @RequestBody SignupRequest signupRequest) {
-        return authService.join(signupRequest);
+    public ResponseEntity<ApiResult<SignupResponse>> join(@Valid @RequestBody SignupRequest signupRequest) {
+        return ResponseEntity.ok(ApiResult.success(authService.join(signupRequest)));
     }
 
     @PostMapping("/login")
-    public SigninResponse login(@Valid @RequestBody SigninRequest signinRequest) {
-        return authService.login(signinRequest);
+    public ResponseEntity<ApiResult<SigninResponse>> login(@Valid @RequestBody SigninRequest signinRequest) {
+        return ResponseEntity.ok(ApiResult.success(authService.login(signinRequest)));
     }
 }

--- a/src/main/java/org/example/expert/domain/comment/controller/CommentAdminController.java
+++ b/src/main/java/org/example/expert/domain/comment/controller/CommentAdminController.java
@@ -13,7 +13,7 @@ public class CommentAdminController {
     private final CommentAdminService commentAdminService;
 
     @DeleteMapping("/admin/comments/{commentId}")
-    public void deleteComment(@PathVariable long commentId) {
+    public void deleteComment(@PathVariable(value = "commentId") Long commentId) {
         commentAdminService.deleteComment(commentId);
     }
 }

--- a/src/main/java/org/example/expert/domain/log/admin/AdminAccessLog.java
+++ b/src/main/java/org/example/expert/domain/log/admin/AdminAccessLog.java
@@ -1,0 +1,47 @@
+package org.example.expert.domain.log.admin;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.expert.domain.common.entity.Timestamped;
+import org.example.expert.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "admin_access_log")
+public class AdminAccessLog extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String requestUrl;
+
+    @Column(columnDefinition = "TEXT")
+    private String requestBody;
+
+    @Column(columnDefinition = "TEXT")
+    private String responseBody;
+
+    @Column(nullable = false)
+    private LocalDateTime accessTime;
+
+    @Builder
+    public AdminAccessLog(User user, String requestUrl, String requestBody, String responseBody, LocalDateTime accessTime) {
+        this.user = user;
+        this.requestUrl = requestUrl;
+        this.requestBody = requestBody;
+        this.responseBody = responseBody;
+        this.accessTime = accessTime;
+    }
+}

--- a/src/main/java/org/example/expert/domain/log/admin/AdminAccessLogRepository.java
+++ b/src/main/java/org/example/expert/domain/log/admin/AdminAccessLogRepository.java
@@ -1,0 +1,8 @@
+package org.example.expert.domain.log.admin;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AdminAccessLogRepository extends JpaRepository<AdminAccessLog, Long> {
+}

--- a/src/main/java/org/example/expert/domain/user/controller/UserAdminController.java
+++ b/src/main/java/org/example/expert/domain/user/controller/UserAdminController.java
@@ -1,10 +1,13 @@
 package org.example.expert.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.expert.config.auth.valid.Auth;
+import org.example.expert.domain.common.dto.AuthUser;
 import org.example.expert.domain.user.dto.request.UserRoleChangeRequest;
 import org.example.expert.domain.user.service.UserAdminService;
+import org.example.expert.util.api.ApiResult;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,8 +17,9 @@ public class UserAdminController {
 
     private final UserAdminService userAdminService;
 
-    @PatchMapping("/admin/users/{userId}")
-    public void changeUserRole(@PathVariable long userId, @RequestBody UserRoleChangeRequest userRoleChangeRequest) {
-        userAdminService.changeUserRole(userId, userRoleChangeRequest);
+    @PatchMapping("/admin/users")
+    public ResponseEntity<ApiResult<String>> changeUserRole(@Auth AuthUser authUser, @RequestBody UserRoleChangeRequest userRoleChangeRequest) {
+        userAdminService.changeUserRole(authUser, userRoleChangeRequest);
+        return ResponseEntity.ok(ApiResult.success("role has been successfully changed!!!!"));
     }
 }

--- a/src/main/java/org/example/expert/domain/user/service/UserAdminService.java
+++ b/src/main/java/org/example/expert/domain/user/service/UserAdminService.java
@@ -1,10 +1,10 @@
 package org.example.expert.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.expert.domain.common.dto.AuthUser;
 import org.example.expert.domain.user.dto.request.UserRoleChangeRequest;
 import org.example.expert.domain.user.entity.User;
 import org.example.expert.domain.user.enums.UserRole;
-import org.example.expert.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,12 +12,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserAdminService {
 
-    private final UserRepository userRepository;
     private final UserService userService;
 
     @Transactional
-    public void changeUserRole(long userId, UserRoleChangeRequest userRoleChangeRequest) {
-        User user = userService.findByIdOrFail(userId);
+    public void changeUserRole(AuthUser authUser, UserRoleChangeRequest userRoleChangeRequest) {
+        User user = userService.findByIdOrFail(authUser.getId());
         user.updateRole(UserRole.of(userRoleChangeRequest.getRole()));
     }
 }


### PR DESCRIPTION
관리자 접근 로깅 중 요청 바디 본문 읽을 때 오류 발생: IllegalStateException, InputStream이 이미 닫혔는데 다시 요청 바디 본문을 읽으려 시도해서 발생한 것

기존 MVC의 요청 처리 순서:
1. 클라이언트 요청 들어옴
2. 필터 체인 통과
3. DS가 요청을 받음
4. ArgumentResolver 동작
    - HttpMessageConverter가 요청 본문을 읽고 객체로 변환
    - 이때 이미 InputStream을 소비
5. AOP
    - getRequestBody() 호출
    - 이미 ArgumentResolve에서 본문을 읽었기 때문에 IllegalStateException 발생
 

따라서 ArgumentResolve가 변환한 객체를 aop로 가져오도록 수정 -> joinPoint에서 메서드 파라미터 꺼내는 방식으로 적용




